### PR TITLE
Update caido download links

### DIFF
--- a/ansible-playbooks/web_tools/install_caido.yml
+++ b/ansible-playbooks/web_tools/install_caido.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download Caido AppImage
   get_url:
-    url: "https://storage.googleapis.com/caido-releases/v0.40.0/caido-desktop-v0.40.0-linux-x86_64.AppImage"
+    url: "https://caido.download/releases/v0.40.0/caido-desktop-v0.40.0-linux-x86_64.AppImage"
     dest: "/tmp/caido.AppImage"
     mode: '0755'
 


### PR DESCRIPTION
Hi! Creator of Caido here.
We are moving away from GCP and onto our own download domain.
Older links won't work within the next 30 days.
Documentation: https://docs.caido.io/concepts/internals/download.html